### PR TITLE
features/index.html error throws a 404

### DIFF
--- a/features/index.html
+++ b/features/index.html
@@ -16,7 +16,7 @@
 
     Say, did you know that when you multiply {{ results['a'] }} by {{ results['b'] }}, you get {{ results['c'] }}?
 
-
+<!-- The a href here doesn't resolve to view the source --!>
     (<a href="index.html-src.html#features-index.html-pyg---126">View the source</a>
     of this page to see how that sentence was put together.)</p>
     <p>This approach means that the code you document is the actual code you use, and it can be run independently, tested, tweaked and updated at any time. You can publish documents with confidence that your examples and results are free from typos and can be easily audited and verified.</p>

--- a/features/index.html
+++ b/features/index.html
@@ -16,7 +16,7 @@
 
     Say, did you know that when you multiply {{ results['a'] }} by {{ results['b'] }}, you get {{ results['c'] }}?
 
-<!-- The a href here doesn't resolve to view the source --!>
+<!-- The a href here doesn't resolve to view the source -->
     (<a href="index.html-src.html#features-index.html-pyg---126">View the source</a>
     of this page to see how that sentence was put together.)</p>
     <p>This approach means that the code you document is the actual code you use, and it can be run independently, tested, tweaked and updated at any time. You can publish documents with confidence that your examples and results are free from typos and can be easily audited and verified.</p>


### PR DESCRIPTION
This page has:
Or you can work the results directly in to your document. Say, did you know that when you multiply 6 by 7, you get 42? (View the source of this page to see how that sentence was put together.)

But "View the source" returns a 404:
The requested URL /features/index.html-src.html was not found on this server.

I added a comment in the source where the error is, but do not know how to resolve it.

Hope this helps.
